### PR TITLE
Fixed a crash as a result of SlotDataTask keeping pointer to previous UWorld

### DIFF
--- a/Source/SaveExtension/Private/SlotDataTask_Loader.cpp
+++ b/Source/SaveExtension/Private/SlotDataTask_Loader.cpp
@@ -35,6 +35,7 @@ void USlotDataTask_Loader::OnStart()
 	}
 
 	//Cross-Level loading
+	const UWorld* World = GetWorld();
 	if (World->GetFName() != NewSlotInfo->Map)
 	{
 		bLoadingMap = true;
@@ -52,6 +53,7 @@ void USlotDataTask_Loader::OnStart()
 
 void USlotDataTask_Loader::OnMapLoaded()
 {
+	const UWorld* World = GetWorld();
 	if (World->GetFName() != NewSlotInfo->Map)
 	{
 		bLoadingMap = false;
@@ -89,6 +91,7 @@ void USlotDataTask_Loader::AfterMapValidation()
 void USlotDataTask_Loader::BeforeDeserialize()
 {
 	// Set current game time to the saved value
+	UWorld* World = GetWorld();
 	World->TimeSeconds = SlotData->TimeSeconds;
 
 	if (Preset->bStoreGameInstance)
@@ -115,7 +118,8 @@ void USlotDataTask_Loader::BeforeDeserialize()
 void USlotDataTask_Loader::DeserializeSync()
 {
 	QUICK_SCOPE_CYCLE_COUNTER(STAT_Loading_DeserializeSync);
-
+	
+	const UWorld* World = GetWorld();
 	check(World);
 	SELog(Preset, "World '" + World->GetName() + "'", FColor::Green, false, 1);
 
@@ -162,6 +166,7 @@ void USlotDataTask_Loader::DeserializeASync()
 {
 	// Deserialize world
 	{
+		const UWorld* World = GetWorld();
 		check(World);
 		SELog(Preset, "World '" + World->GetName() + "'", FColor::Green, false, 1);
 
@@ -299,6 +304,7 @@ void USlotDataTask_Loader::PrepareAllLevels()
 	QUICK_SCOPE_CYCLE_COUNTER(STAT_Loading_PrepareAllLevels);
 
 	// Prepare Main level
+	const UWorld* World = GetWorld();
 	PrepareLevel(World->GetCurrentLevel(), SlotData->MainLevel);
 
 	// Prepare other loaded sub-levels
@@ -324,10 +330,10 @@ void USlotDataTask_Loader::RespawnActors(const TArray<FActorRecord>& Records, co
 	SpawnInfo.OverrideLevel = const_cast<ULevel*>(Level);
 
 	// Respawn all procedural actors
+	UWorld* World = GetWorld();
 	for (const auto& Record : Records)
 	{
 		SpawnInfo.Name = Record.Name;
-
 		World->SpawnActor(Record.Class.Get(), &Record.Transform, SpawnInfo);
 	}
 }
@@ -409,6 +415,7 @@ void USlotDataTask_Loader::DeserializeAI(AAIController* AIController, const FLev
 
 void USlotDataTask_Loader::DeserializeGameMode()
 {
+	const UWorld* World = GetWorld();
 	const FActorRecord& Record = SlotData->GameMode;
 	const bool bSuccess = DeserializeActor(World->GetAuthGameMode(), Record);
 
@@ -417,6 +424,7 @@ void USlotDataTask_Loader::DeserializeGameMode()
 
 void USlotDataTask_Loader::DeserializeGameState()
 {
+	const UWorld* World = GetWorld();
 	auto* GameState = World->GetGameState();
 
 	const FActorRecord& Record = SlotData->GameState;
@@ -427,6 +435,7 @@ void USlotDataTask_Loader::DeserializeGameState()
 
 void USlotDataTask_Loader::DeserializePlayerState(int32 PlayerId)
 {
+	const UWorld* World = GetWorld();
 	const auto* Controller = UGameplayStatics::GetPlayerController(World, PlayerId);
 	if (!Controller)
 		return;
@@ -439,6 +448,7 @@ void USlotDataTask_Loader::DeserializePlayerState(int32 PlayerId)
 
 void USlotDataTask_Loader::DeserializePlayerController(int32 PlayerId)
 {
+	const UWorld* World = GetWorld();
 	auto* Controller = UGameplayStatics::GetPlayerController(World, PlayerId);
 
 	const FControllerRecord& Record = SlotData->PlayerController;
@@ -449,6 +459,7 @@ void USlotDataTask_Loader::DeserializePlayerController(int32 PlayerId)
 
 void USlotDataTask_Loader::DeserializePlayerHUD(int32 PlayerId)
 {
+	const UWorld* World = GetWorld();
 	const auto* Controller = UGameplayStatics::GetPlayerController(World, PlayerId);
 	if (!Controller)
 		return;
@@ -462,6 +473,7 @@ void USlotDataTask_Loader::DeserializePlayerHUD(int32 PlayerId)
 void USlotDataTask_Loader::DeserializeGameInstance()
 {
 	bool bSuccess = true;
+	const UWorld* World = GetWorld();
 	auto* GameInstance = World->GetGameInstance();
 	const FObjectRecord& Record = SlotData->GameInstance;
 
@@ -620,7 +632,8 @@ FLevelRecord* USlotDataTask_Loader::FindLevelRecord(const ULevelStreaming* Level
 void USlotDataTask_Loader::FindNextAsyncLevel(ULevelStreaming*& OutLevelStreaming) const
 {
 	OutLevelStreaming = nullptr;
-
+	
+	const UWorld* World = GetWorld();
 	const TArray<ULevelStreaming*>& Levels = World->GetStreamingLevels();
 	if (CurrentLevel.IsValid() && Levels.Num() > 0)
 	{

--- a/Source/SaveExtension/Private/SlotDataTask_Saver.cpp
+++ b/Source/SaveExtension/Private/SlotDataTask_Saver.cpp
@@ -291,6 +291,7 @@ void USlotDataTask_Saver::OnStart()
 
 	if (bSave)
 	{
+		const UWorld* World = GetWorld();
 		GetManager()->OnSaveBegan();
 
 		USlotInfo* CurrentInfo = Manager->GetCurrentInfo();
@@ -374,6 +375,7 @@ void USlotDataTask_Saver::BeginDestroy()
 void USlotDataTask_Saver::SerializeSync()
 {
 	// Has Authority
+	const UWorld* World = GetWorld();
 	if (World->GetAuthGameMode())
 	{
 		// Save World
@@ -383,6 +385,7 @@ void USlotDataTask_Saver::SerializeSync()
 
 void USlotDataTask_Saver::SerializeWorld()
 {
+	const UWorld* World = GetWorld();
 	check(World);
 	SELog(Preset, "World '" + World->GetName() + "'", FColor::Green, false, 1);
 
@@ -430,6 +433,7 @@ void USlotDataTask_Saver::SerializeWorld()
 
 void USlotDataTask_Saver::SerializeLevelSync(const ULevel* Level, int32 AssignedTasks, const ULevelStreaming* StreamingLevel)
 {
+	const UWorld* World = GetWorld();
 	check(IsValid(Level));
 
 	if (Preset->IsMTSerializationSave())

--- a/Source/SaveExtension/Public/SlotDataTask.h
+++ b/Source/SaveExtension/Public/SlotDataTask.h
@@ -51,8 +51,8 @@ protected:
 	UPROPERTY()
 	USlotData* SlotData;
 
-	UPROPERTY()
-	UWorld* World;
+	//UPROPERTY()
+	//UWorld* World;
 
 	UPROPERTY()
 	const USavePreset* Preset;
@@ -68,7 +68,7 @@ public:
 	void Prepare(USlotData* InSaveData, UWorld* InWorld, const USavePreset* InPreset)
 	{
 		SlotData = InSaveData;
-		World = InWorld;
+		//World = InWorld;
 		Preset = InPreset;
 		MaxFrameMs = Preset? Preset->GetMaxFrameMs() : 5.f;
 	}


### PR DESCRIPTION
SlotDataTask keeping pointer to previous UWorld was causing a crash when calling USaveManager::LoadSlotFromId if that resulted in a map change. Instead of storing the pointer to the UWorld, world is resolved on the fly via GetWorld(). Thus the old world can be garbage collected as part of the map change and after the map change, the task will continue deserializing using the new World.