### PR TITLE
Fix strict include compile error

### DIFF
--- a/Source/Editor/Private/Customizations/ClassFilter/ClassFilterHelpers.h
+++ b/Source/Editor/Private/Customizations/ClassFilter/ClassFilterHelpers.h
@@ -170,7 +170,7 @@ namespace ClassFilter
 		 * @param InClass					The class to verify can be made into a Blueprint
 		 * @return							TRUE if the class can be made into a Blueprint
 		 */
-		bool CanCreateBlueprintOfClass_IgnoreDeprecation(UClass* InClass)
+		static bool CanCreateBlueprintOfClass_IgnoreDeprecation(UClass* InClass)
 		{
 			// Temporarily remove the deprecated flag so we can check if it is valid for
 			bool bIsClassDeprecated = InClass->HasAnyClassFlags(CLASS_Deprecated);

--- a/Source/Editor/Private/Customizations/ClassFilter/ClassFilterHelpers.h
+++ b/Source/Editor/Private/Customizations/ClassFilter/ClassFilterHelpers.h
@@ -21,6 +21,7 @@
 #include <Framework/Multibox/MultiBoxBuilder.h>
 #include <Misc/FeedbackContext.h>
 #include <Misc/ConfigCacheIni.h>
+#include "Misc/ClassFilter.h"
 
 #define LOCTEXT_NAMESPACE "ClassFilterHelpers"
 

--- a/Source/Editor/Private/Customizations/ComponentClassFilterCustomization.cpp
+++ b/Source/Editor/Private/Customizations/ComponentClassFilterCustomization.cpp
@@ -1,6 +1,7 @@
 // Copyright 2015-2019 Piperift. All Rights Reserved.
 
 #include "Customizations/ComponentClassFilterCustomization.h"
+#include "PropertyHandle.h"
 
 #define LOCTEXT_NAMESPACE "FComponentClassFilterCustomization"
 

--- a/Source/Editor/Private/SaveExtensionEditor.cpp
+++ b/Source/Editor/Private/SaveExtensionEditor.cpp
@@ -89,3 +89,4 @@ void FSaveExtensionEditor::RegisterCustomPinFactory()
 }
 
 #undef LOCTEXT_NAMESPACE
+IMPLEMENT_MODULE(FSaveExtensionEditor, SaveExtensionEditor);

--- a/Source/Editor/Private/SaveExtensionEditor.h
+++ b/Source/Editor/Private/SaveExtensionEditor.h
@@ -97,4 +97,4 @@ private:
 	TArray<TSharedPtr<FGraphPanelPinFactory>> CreatedPinFactories;
 };
 
-IMPLEMENT_MODULE(FSaveExtensionEditor, SaveExtensionEditor);
+

--- a/Source/SaveExtension/Private/Misc/SlotHelpers.cpp
+++ b/Source/SaveExtension/Private/Misc/SlotHelpers.cpp
@@ -2,6 +2,7 @@
 
 #include <Misc/SlotHelpers.h>
 #include <Misc/Paths.h>
+#include <HAL/PlatformFilemanager.h>
 
 
 void FSlotHelpers::GetSlotFileNames(TArray<FString>& FoundFiles, bool bOnlyInfos, bool bOnlyDatas)

--- a/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
+++ b/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
@@ -2,6 +2,7 @@
 
 #include "Serialization/MTTask_SerializeActors.h"
 #include <Serialization/MemoryWriter.h>
+#include <Components/PrimitiveComponent.h>
 
 #include "SaveManager.h"
 #include "SlotInfo.h"

--- a/Source/SaveExtension/Private/Serialization/SEArchive.cpp
+++ b/Source/SaveExtension/Private/Serialization/SEArchive.cpp
@@ -1,6 +1,7 @@
 // Copyright 2015-2019 Piperift. All Rights Reserved.
 
 #include "Serialization/SEArchive.h"
+#include <UObject/NoExportTypes.h>
 
 
 /////////////////////////////////////////////////////

--- a/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
+++ b/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
@@ -4,6 +4,8 @@
 
 #include <GameFramework/Character.h>
 #include <Serialization/MemoryReader.h>
+#include <Kismet/GameplayStatics.h>
+#include <Components/PrimitiveComponent.h>
 
 #include "SavePreset.h"
 #include "SaveManager.h"

--- a/Source/SaveExtension/Public/Serialization/MTTask.h
+++ b/Source/SaveExtension/Public/Serialization/MTTask.h
@@ -10,6 +10,7 @@
 #include <GameFramework/Controller.h>
 
 #include "SavePreset.h"
+#include "SaveFilter.h"
 
 
 /////////////////////////////////////////////////////

--- a/Source/SaveExtension/Public/Serialization/MTTask_SerializeActors.h
+++ b/Source/SaveExtension/Public/Serialization/MTTask_SerializeActors.h
@@ -12,6 +12,8 @@
 #include "SavePreset.h"
 
 #include "MTTask.h"
+#include "Serialization/Records.h"
+#include "Serialization/LevelRecords.h"
 
 
 class USlotData;


### PR DESCRIPTION
Hi, this pull request fix compile error when compile plugin using following command:

`RunUAT.bat BuildPlugin -StrictIncludes -Plugin="/Path/To/Plugins/SaveExtension/SaveExtension.uplugin" -TargetPlatforms="Win64" -nop4 -ue4exe="/Path/To/Engine/Binaries/Win64/UE4Editor-Cmd.exe" -Package="/Path/To/PackagePlugin/Plugin/Win64/feature/SaveGame/"`
