### PR TITLE
Fix Save and Load for 4.24

### DIFF
--- a/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
+++ b/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
@@ -23,7 +23,7 @@ void FMTTask_SerializeActors::DoWork()
 	for (int32 I = 0; I < Num; ++I)
 	{
 		const AActor* const Actor = (*LevelActors)[StartIndex + I];
-		if (Filter.ShouldSave(Actor))
+		if (Actor && Filter.ShouldSave(Actor))
 		{
 			FActorRecord Record;
 			SerializeActor(Actor, Record);

--- a/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
+++ b/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
@@ -92,6 +92,7 @@ void USlotDataTask_Loader::OnMapLoaded()
 	const UWorld* World = GetWorld();
 	if (World->GetFName() == NewSlotInfo->Map)
 	{
+		Filter.BakeAllowedClasses();
 		bLoadingMap = false;
 
 		if(IsDataLoaded())

--- a/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
+++ b/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
@@ -308,7 +308,7 @@ void USlotDataTask_Loader::PrepareLevel(const ULevel* Level, const FLevelRecord&
 			// Remove records which actors do exist
 			const bool bFoundActorRecord = ActorsToSpawn.RemoveSingleSwap(Actor, false) > 0;
 
-			if (Filter.ShouldSave(Actor))
+			if (Actor && Filter.ShouldSave(Actor))
 			{
 				if (!bFoundActorRecord) // Don't destroy level actors
 				{
@@ -379,7 +379,7 @@ void USlotDataTask_Loader::DeserializeLevel_Actor(AActor* const Actor, const FLe
 {
 	QUICK_SCOPE_CYCLE_COUNTER(STAT_Loading_DeserializeLevel_Actor);
 
-	if (Filter.ShouldSave(Actor))
+	if (Actor && Filter.ShouldSave(Actor))
 	{
 		// Find the record
 		const FActorRecord* const Record = LevelRecord.Actors.FindByKey(Actor);

--- a/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
+++ b/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
@@ -304,11 +304,12 @@ void USlotDataTask_Loader::PrepareLevel(const ULevel* Level, const FLevelRecord&
 		for (auto ActorItr = Level->Actors.CreateConstIterator(); ActorItr; ++ActorItr)
 		{
 			AActor* const Actor{ *ActorItr };
+
+			// Remove records which actors do exist
+			const bool bFoundActorRecord = ActorsToSpawn.RemoveSingleSwap(Actor, false) > 0;
+
 			if (Filter.ShouldSave(Actor))
 			{
-				// Remove records which actors do exist
-				const bool bFoundActorRecord = ActorsToSpawn.RemoveSingleSwap(Actor, false) > 0;
-
 				if (!bFoundActorRecord) // Don't destroy level actors
 				{
 					// If the actor wasn't found, mark it for destruction

--- a/Source/SaveExtension/Private/Serialization/SlotDataTask_Saver.cpp
+++ b/Source/SaveExtension/Private/Serialization/SlotDataTask_Saver.cpp
@@ -110,6 +110,17 @@ void USlotDataTask_Saver::OnStart()
 	Finish(false);
 }
 
+void USlotDataTask_Saver::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+	if (SaveInfoTask && SaveDataTask && 
+		SaveInfoTask->IsDone() && SaveDataTask->IsDone())
+	{
+		Finish(true);
+	}
+}
+
 void USlotDataTask_Saver::OnFinish(bool bSuccess)
 {
 	if (bSuccess)

--- a/Source/SaveExtension/Public/SaveFilter.h
+++ b/Source/SaveExtension/Public/SaveFilter.h
@@ -59,9 +59,17 @@ public:
 		ComponentFilter     = Preset.GetComponentFilter(true);
 		LoadActorFilter     = Preset.GetActorFilter(false);
 		LoadComponentFilter = Preset.GetComponentFilter(false);
-
+		BakeAllowedClasses();
 		MaxFrameMs       = Preset.GetMaxFrameMs();
 		bStoreComponents = Preset.bStoreComponents;
+	}
+
+	void BakeAllowedClasses()
+	{
+		ActorFilter.BakeAllowedClasses();
+		ComponentFilter.BakeAllowedClasses();
+		LoadActorFilter.BakeAllowedClasses();
+		LoadComponentFilter.BakeAllowedClasses();
 	}
 
 	FORCEINLINE bool ShouldSave(const AActor* Actor) const

--- a/Source/SaveExtension/Public/Serialization/SlotDataTask_Saver.h
+++ b/Source/SaveExtension/Public/Serialization/SlotDataTask_Saver.h
@@ -85,7 +85,7 @@ public:
 
 	// Where all magic happens
 	virtual void OnStart() override;
-
+	virtual void Tick(float DeltaTime) override;
 	virtual void OnFinish(bool bSuccess) override;
 	virtual void BeginDestroy() override;
 


### PR DESCRIPTION
hi,

This PR fix some save & load functions for me in 4.24.

To summarize this PR is:
1.  We need BakeAllowedClasses for FSaveFilter to work properly.
2.  USlotDataTask_Saver never fnished, so should check SaveInfoTask and SaveDataTask IsDone in Tick.
3.  Don't respawn actor if it already exist in level because FActorSpawnParameters will override existing actor's value that will be wrong if DeserializeLevel_Actor didn't have "correct value" for the actor.
