### PR TITLE
[BugFix] Fix GetSlotFileNames crash

### DIFF
--- a/Source/SaveExtension/Private/Misc/SlotHelpers.cpp
+++ b/Source/SaveExtension/Private/Misc/SlotHelpers.cpp
@@ -26,26 +26,32 @@ bool FSlotHelpers::FFindSlotVisitor::Visit(const TCHAR* FilenameOrDirectory, boo
 		FString FullFilePath(FilenameOrDirectory);
 		if (FPaths::GetExtension(FullFilePath) == TEXT("sav"))
 		{
-			FString CleanFilename = FPaths::GetBaseFilename(FullFilePath);
-			CleanFilename.RemoveFromEnd(".sav");
+			FString SaveFilename;
+			FString SaveFolder;
+			FString SaveExtension;
+			FPaths::Split(FullFilePath, SaveFolder, SaveFilename, SaveExtension);
 
 			if (bOnlyInfos)
 			{
-				if (!CleanFilename.EndsWith("_data"))
+				if (!SaveFilename.EndsWith("_data"))
 				{
-					FilesFound.Add(CleanFilename);
+					// Find USlotInfo file if only if it has USlotData file
+					if (FPaths::FileExists(SaveFolder / SaveFilename + TEXT("_data.") + SaveExtension))
+					{
+						FilesFound.Add(SaveFilename);
+					}
 				}
 			}
 			else if (bOnlyDatas)
 			{
-				if (CleanFilename.EndsWith("_data"))
+				if (SaveFilename.EndsWith("_data"))
 				{
-					FilesFound.Add(CleanFilename);
+					FilesFound.Add(SaveFilename);
 				}
 			}
 			else
 			{
-				FilesFound.Add(CleanFilename);
+				FilesFound.Add(SaveFilename);
 			}
 		}
 	}


### PR DESCRIPTION
Fix GetSlotFileNames crash if there has other save data that are not generated by SaveExtension

Add to FilesFound only if we find _data.sav