### PR TITLE
Fix for accessing invalid memory in FMTTask_SerializeActors::DumpData()

### DIFF
--- a/Source/SaveExtension/Private/Serialization/SlotDataTask_Saver.cpp
+++ b/Source/SaveExtension/Private/Serialization/SlotDataTask_Saver.cpp
@@ -206,17 +206,16 @@ void USlotDataTask_Saver::SerializeLevelSync(const ULevel* Level, int32 Assigned
 
 
 	// Find level record. By default, main level
-	FLevelRecord* LevelRecord = &SlotData->MainLevel;
+	int LevelRecordId = USlotData::MainLevelRecordId;
 	if (StreamingLevel)
 	{
 		// Find or create the sub-level
 		const int32 Index = SlotData->SubLevels.AddUnique({ StreamingLevel });
-		LevelRecord = &SlotData->SubLevels[Index];
+		LevelRecordId = Index;
 	}
-	check(LevelRecord);
 
 	// Empty level record before serializing it
-	LevelRecord->Clean();
+	SlotData->GetLevelRecord(LevelRecordId)->Clean();
 
 	Filter.BakeAllowedClasses();
 
@@ -235,7 +234,7 @@ void USlotDataTask_Saver::SerializeLevelSync(const ULevel* Level, int32 Assigned
 
 		// Add new Task
 		Tasks.Emplace(FMTTask_SerializeActors{
-			GetWorld(), SlotData, &Level->Actors, Index, NumToSerialize, LevelRecord, Filter});
+			GetWorld(), SlotData, &Level->Actors, Index, NumToSerialize, LevelRecordId, Filter});
 
 		Index += NumToSerialize;
 	}

--- a/Source/SaveExtension/Public/Serialization/MTTask_SerializeActors.h
+++ b/Source/SaveExtension/Public/Serialization/MTTask_SerializeActors.h
@@ -34,7 +34,7 @@ class FMTTask_SerializeActors : public FMTTask
 	const int32 Num;
 
 	/** USE ONLY FOR DUMPING DATA */
-	FLevelRecord* LevelRecord;
+	int LevelRecordId;
 
 	FActorRecord LevelScriptRecord;
 	TArray<FActorRecord> ActorRecords;
@@ -43,12 +43,12 @@ class FMTTask_SerializeActors : public FMTTask
 public:
 	FMTTask_SerializeActors(const UWorld* World, USlotData* SlotData,
 		const TArray<AActor*>* const InLevelActors, const int32 InStartIndex, const int32 InNum,
-		FLevelRecord* InLevelRecord, const FSaveFilter& Filter)
+		int InLevelRecordId, const FSaveFilter& Filter)
 		: FMTTask(false, World, SlotData, Filter)
 		, LevelActors(InLevelActors)
 		, StartIndex(InStartIndex)
 		, Num(InNum)
-		, LevelRecord(InLevelRecord)
+		, LevelRecordId(InLevelRecordId)
 		, LevelScriptRecord{}
 		, ActorRecords{}
 	{
@@ -60,6 +60,9 @@ public:
 
 	/** Called after task has completed to recover resulting information */
 	void DumpData() {
+
+		FLevelRecord* LevelRecord = SlotData->GetLevelRecord(LevelRecordId);
+
 		if (LevelScriptRecord.IsValid())
 			LevelRecord->LevelScript = LevelScriptRecord;
 

--- a/Source/SaveExtension/Public/SlotData.h
+++ b/Source/SaveExtension/Public/SlotData.h
@@ -57,4 +57,17 @@ public:
 
 	/** Using manual serialization. It's way faster than reflection serialization */
 	virtual void Serialize(FArchive& Ar) override;
+
+    static const int MainLevelRecordId = -1;
+	FLevelRecord* GetLevelRecord(int LevelRecordId) 
+	{ 
+		if (LevelRecordId == MainLevelRecordId)
+		{
+			return &MainLevel;
+		}
+		else
+		{
+			return &SubLevels[LevelRecordId];
+		}
+	}
 };


### PR DESCRIPTION
In the previous implementation FMTTask_SerializeActors is passed a pointer to a LevelRecord in the SubLevels array that can subsequently be made invalid by calling SlotData->SubLevels.AddUnique(). This bug will occur if there are enough sublevels to require the SubLevels array to resize, which will change where they are in memory. The affect is either data not being saved or the application crashing.

In the new implementation an id is used to store a reference to the level (either the array index of the level or -1 to indicate the persistent level) instead of a pointer.