### PR TITLE
Support serialize/deserialize single actor, and add more event to LifetimeComponent

### DIFF
--- a/Source/SaveExtension/Private/LifetimeComponent.cpp
+++ b/Source/SaveExtension/Private/LifetimeComponent.cpp
@@ -20,7 +20,7 @@ void ULifetimeComponent::BeginPlay()
 		// this actor and its not a natural start
 		if (!Manager->IsLoading())
 		{
-			Start.Broadcast();
+			OnStart.Broadcast();
 		}
 	}
 	else
@@ -37,7 +37,7 @@ void ULifetimeComponent::EndPlay(EEndPlayReason::Type Reason)
 		// this actor and its not a natural destroy
 		if (!Manager->IsLoading())
 		{
-			Finish.Broadcast();
+			OnFinish.Broadcast();
 		}
 
 		Manager->UnsubscribeFromEvents(this);
@@ -50,7 +50,24 @@ void ULifetimeComponent::OnSaveBegan(const FSELevelFilter& Filter)
 {
 	if (Filter.ShouldSave(GetOwner()))
 	{
-		Saved.Broadcast();
+		OnSave.Broadcast();
+	}
+}
+
+void ULifetimeComponent::OnSaveFinished(const FSELevelFilter& Filter, bool bError)
+{
+	if (Filter.ShouldSave(GetOwner()))
+	{
+		OnSaved.Broadcast();
+	}
+}
+
+
+void ULifetimeComponent::OnLoadBegan(const FSELevelFilter& Filter)
+{
+	if (Filter.ShouldSave(GetOwner()))
+	{
+		OnResume.Broadcast();
 	}
 }
 
@@ -58,6 +75,6 @@ void ULifetimeComponent::OnLoadFinished(const FSELevelFilter& Filter, bool bErro
 {
 	if (Filter.ShouldSave(GetOwner()))
 	{
-		Resume.Broadcast();
+		OnResumed.Broadcast();
 	}
 }

--- a/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
+++ b/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
@@ -27,7 +27,7 @@ void FMTTask_SerializeActors::DoWork()
 		if (Actor && Filter.ShouldSave(Actor))
 		{
 			FActorRecord& Record = ActorRecords.AddDefaulted_GetRef();
-			SerializeActor(Actor, Record);
+			SerializeActor(Actor, Record, Filter);
 		}
 	}
 }
@@ -48,8 +48,7 @@ void FMTTask_SerializeActors::SerializeGameInstance()
 	}
 }
 
-bool FMTTask_SerializeActors::SerializeActor(const AActor* Actor, FActorRecord& Record) const
-{
+bool FMTTask_SerializeActors::SerializeActor(const AActor* Actor, FActorRecord& Record, const FSELevelFilter &Filter) {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FMTTask_SerializeActors::SerializeActor);
 
 	//Clean the record
@@ -98,7 +97,7 @@ bool FMTTask_SerializeActors::SerializeActor(const AActor* Actor, FActorRecord& 
 
 	if (Filter.bStoreComponents)
 	{
-		SerializeActorComponents(Actor, Record, 1);
+		SerializeActorComponents(Actor, Record, Filter, 1);
 	}
 
 	TRACE_CPUPROFILER_EVENT_SCOPE(Serialize);
@@ -109,8 +108,9 @@ bool FMTTask_SerializeActors::SerializeActor(const AActor* Actor, FActorRecord& 
 	return true;
 }
 
-void FMTTask_SerializeActors::SerializeActorComponents(const AActor* Actor, FActorRecord& ActorRecord, int8 Indent /*= 0*/) const
-{
+void FMTTask_SerializeActors::SerializeActorComponents(
+	const AActor* Actor, FActorRecord& ActorRecord, const FSELevelFilter &Filter, int8 Indent /*= 0*/
+) {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FMTTask_SerializeActors::SerializeActorComponents);
 
 	const TSet<UActorComponent*>& Components = Actor->GetComponents();

--- a/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
+++ b/Source/SaveExtension/Private/Serialization/SlotDataTask_Loader.cpp
@@ -562,9 +562,8 @@ void USlotDataTask_Loader::DeserializeActorComponents(AActor* Actor, const FActo
 
 			// Find the record
 			const FComponentRecord* Record = ActorRecord.ComponentRecords.FindByKey(Component);
-			if (!Record)
-			{
-				SELog(Preset, "Component '" + Component->GetFName().ToString() + "' - Record not found", FColor::Red, false, Indent + 1);
+			if (!Record) {
+				// SELog(Preset, "Component '" + Component->GetFName().ToString() + "' - Record not found", FColor::Red, false, Indent + 1);
 				continue;
 			}
 

--- a/Source/SaveExtension/Public/LifetimeComponent.h
+++ b/Source/SaveExtension/Public/LifetimeComponent.h
@@ -13,9 +13,11 @@
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLifetimeStartSignature);
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLifetimeSaveSignature);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLifetimeSavedSignature);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLifetimeResumeSignature);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLifetimeResumedSignature);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLifetimeFinishSignature);
 
@@ -40,11 +42,13 @@ public:
 	virtual void EndPlay(EEndPlayReason::Type Reason) override;
 
 
-	// Event called when Save process starts
+	// Event called when Save process
 	virtual void OnSaveBegan(const FSELevelFilter& Filter) override;
+	virtual void OnSaveFinished(const FSELevelFilter& Filter, bool bError) override;
 
-	// Event called when Load process ends
-	virtual void OnLoadFinished(const FSELevelFilter& Filter, bool bError);
+	// Event called when Load process
+	virtual void OnLoadBegan(const FSELevelFilter& Filter) override;
+	virtual void OnLoadFinished(const FSELevelFilter& Filter, bool bError) override;
 
 
 	USaveManager* GetManager() const
@@ -60,25 +64,35 @@ protected:
 
 	// Called once when this actor gets created for the first time. Similar to BeginPlay
 	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
-	FLifetimeStartSignature Start;
+	FLifetimeStartSignature OnStart;
 
-	// Called when game is saved
+	// Called when begin save
 	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
-	FLifetimeSavedSignature Saved;
+	FLifetimeSaveSignature OnSave;
 
-	// Called when game loaded
+	// Called when after save
 	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
-	FLifetimeResumeSignature Resume;
+	FLifetimeSavedSignature OnSaved;
+
+	// Called when before load
+	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
+	FLifetimeResumeSignature OnResume;
+
+	// Called when after load
+	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
+	FLifetimeResumedSignature OnResumed;
 
 	// Called when this actor gets destroyed for ever
 	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
-	FLifetimeFinishSignature Finish;
+	FLifetimeFinishSignature OnFinish;
 
 
 public:
 
-	FLifetimeStartSignature& OnStart() { return Start; }
-	FLifetimeSavedSignature& OnSaved() { return Saved; }
-	FLifetimeResumeSignature& OnResume() { return Resume; }
-	FLifetimeFinishSignature& OnFinish() { return Finish; }
+	// FLifetimeStartSignature& OnStart() { return Start; }
+	// FLifetimeSaveSignature& OnSave() { return Save; }
+	// FLifetimeSavedSignature& OnSaved() { return Saved; }
+	// FLifetimeResumeSignature& OnResume() { return Resume; }
+	// FLifetimeResumedSignature& OnResumed() { return Resumed; }
+	// FLifetimeFinishSignature& OnFinish() { return Finish; }
 };

--- a/Source/SaveExtension/Public/Multithreading/LoadFileTask.h
+++ b/Source/SaveExtension/Public/Multithreading/LoadFileTask.h
@@ -4,6 +4,7 @@
 
 #include <Async/AsyncWork.h>
 #include "FileAdapter.h"
+#include "SaveManager.h"
 
 
 /////////////////////////////////////////////////////

--- a/Source/SaveExtension/Public/SaveManager.h
+++ b/Source/SaveExtension/Public/SaveManager.h
@@ -25,6 +25,8 @@
 
 #include "SaveManager.generated.h"
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnBeginGameSaveMC);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnBeginGameLoadMC);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGameSavedMC, USlotInfo*, SlotInfo);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGameLoadedMC, USlotInfo*, SlotInfo);
@@ -256,6 +258,13 @@ public:
 		return ActivePreset;
 	}
 
+ 	UFUNCTION(BlueprintCallable, Category = "SaveExtension", meta = (DisplayName = "Serialize Actor"))
+ 	bool SerializeActor(const AActor *Actor, FActorRecord &Record);
+
+ 	UFUNCTION(BlueprintCallable, Category = "SaveExtension", meta = (DisplayName = "Deserialize Actor"))
+ 	bool DeserializeActor(AActor *Actor, const FActorRecord Record);
+
+
 
 	/** BLUEPRINTS & C++ API */
 public:
@@ -411,6 +420,12 @@ protected:
 	/***********************************************************************/
 public:
 	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
+	FOnBeginGameSaveMC OnBeginGameSave;
+
+	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
+	FOnBeginGameLoadMC OnBeginGameLoad;
+
+	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
 	FOnGameSavedMC OnGameSaved;
 
 	UPROPERTY(BlueprintAssignable, Category = SaveExtension)
@@ -449,7 +464,7 @@ public:
 	/* DEPRECATED                                                          */
 	/***********************************************************************/
 
-	UFUNCTION(Category = "SaveExtension|Saving", BlueprintCallable, meta = (DeprecatedFunction, DeprecationMessage="Use 'Save Slot by Id' instead.", 
+	UFUNCTION(Category = "SaveExtension|Saving", BlueprintCallable, meta = (DeprecatedFunction, DeprecationMessage="Use 'Save Slot by Id' instead.",
 		AdvancedDisplay = "bScreenshot, Size", DisplayName = "Save Slot to Id", Latent, LatentInfo = "LatentInfo", ExpandEnumAsExecs = "Result", UnsafeDuringActorConstruction))
 	void BPSaveSlotToId(int32 SlotId, bool bScreenshot, const FScreenshotSize Size, ESaveGameResult& Result, FLatentActionInfo LatentInfo, bool bOverrideIfNeeded = true)
 	{

--- a/Source/SaveExtension/Public/Serialization/MTTask_SerializeActors.h
+++ b/Source/SaveExtension/Public/Serialization/MTTask_SerializeActors.h
@@ -74,13 +74,12 @@ public:
 		RETURN_QUICK_DECLARE_CYCLE_STAT(FMTTask_SerializeActors, STATGROUP_ThreadPoolAsyncTasks);
 	}
 
+ 	static bool SerializeActor(const AActor* Actor, FActorRecord& Record, const FSELevelFilter &Filter);
+ 	static void SerializeActorComponents(
+ 		const AActor* Actor, FActorRecord& ActorRecord, const FSELevelFilter &Filter, int8 indent = 0
+ 	);
+
 private:
 
 	void SerializeGameInstance();
-
-	/** Serializes an actor into this Actor Record */
-	bool SerializeActor(const AActor* Actor, FActorRecord& Record) const;
-
-	/** Serializes the components of an actor into a provided Actor Record */
-	inline void SerializeActorComponents(const AActor* Actor, FActorRecord& ActorRecord, int8 indent = 0) const;
 };

--- a/Source/SaveExtension/Public/Serialization/Records.h
+++ b/Source/SaveExtension/Public/Serialization/Records.h
@@ -12,7 +12,7 @@
 class USlotData;
 
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FBaseRecord
 {
 	GENERATED_BODY()

--- a/Source/SaveExtension/Public/Serialization/SlotDataTask_Loader.h
+++ b/Source/SaveExtension/Public/Serialization/SlotDataTask_Loader.h
@@ -76,6 +76,12 @@ public:
 
 	void OnMapLoaded();
 
+ 	/** Serializes an actor into this Actor Record */
+ 	static bool DeserializeActor(AActor* Actor, const FActorRecord& Record, const FSELevelFilter& Filter);
+
+ 	/** Deserializes the components of an actor from a provided Record */
+ 	static void DeserializeActorComponents(AActor* Actor, const FActorRecord& ActorRecord, const FSELevelFilter& Filter, int8 indent = 0);
+
 private:
 
 	virtual void OnStart() override;
@@ -124,11 +130,4 @@ private:
 	/** Deserializes Game Instance Object and its Properties.
 	Requires 'SaveGameMode' flag to be used. */
 	void DeserializeGameInstance();
-
-	/** Serializes an actor into this Actor Record */
-	bool DeserializeActor(AActor* Actor, const FActorRecord& Record, const FSELevelFilter& Filter);
-
-	/** Deserializes the components of an actor from a provided Record */
-	void DeserializeActorComponents(AActor* Actor, const FActorRecord& ActorRecord, const FSELevelFilter& Filter, int8 indent = 0);
-	/** END Deserialization */
 };


### PR DESCRIPTION
When changing the level, we can temporarily save the actor data to the game instance and restore it to the new actor at the new level.