### PR TITLE
fix: loading saves from different levels [4.26]

### DIFF
--- a/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
+++ b/Source/SaveExtension/Private/Serialization/MTTask_SerializeActors.cpp
@@ -57,6 +57,7 @@ bool FMTTask_SerializeActors::SerializeActor(const AActor* Actor, FActorRecord& 
 
 	Record.bHiddenInGame = Actor->IsHidden();
 	Record.bIsProcedural = Filter.IsProcedural(Actor);
+	Record.ClassName = Actor->GetClass()->GetPathName();
 
 	if (Filter.StoresTags(Actor))
 	{

--- a/Source/SaveExtension/Private/Serialization/Records.cpp
+++ b/Source/SaveExtension/Private/Serialization/Records.cpp
@@ -20,6 +20,7 @@ FObjectRecord::FObjectRecord(const UObject* Object) : Super()
 	{
 		Name = Object->GetFName();
 		Class = Object->GetClass();
+		ClassName = Object->GetClass()->GetFullName();
 	}
 }
 
@@ -32,6 +33,7 @@ bool FObjectRecord::Serialize(FArchive& Ar)
 	else if (Ar.IsLoading())
 		Class = nullptr;
 
+	Ar << ClassName;
 	if (Class)
 	{
 		Ar << Data;

--- a/Source/SaveExtension/Public/Serialization/SlotDataTask_Loader.h
+++ b/Source/SaveExtension/Public/Serialization/SlotDataTask_Loader.h
@@ -120,6 +120,8 @@ protected:
 	void FindNextAsyncLevel(ULevelStreaming*& OutLevelStreaming) const;
 
 private:
+	// Returns a class with the given name
+	UClass* GetClassFromName(const FString& ClassName) const;
 
 	/** Deserializes Game Instance Object and its Properties.
 	Requires 'SaveGameMode' flag to be used. */


### PR DESCRIPTION
On Unreal Engine 4.26, if you have a save on `level_one` and try loading it from `level_two`, the game would crash.

After some debugging, I found that this crash was happening due to the way we were storing the actors' static classes. Each save file stores a pointer to the actor's class reference when serializing. This issue is not a problem within the editor because it preserves the references whereas in a packaged build, none of those references exist unless you're already in the level you're trying to load. That reference gets destroyed when going to a new level, causing the crashes [here](https://github.com/PipeRift/SaveExtension/compare/main...leonardparisi:SaveExtension:cross-map-loading-fix?expand=1#diff-5ca5f9b6918c89e60a67aa2a48eb82bef91c028930c9b0f5822f71e1537da1d9L469)

The changes in this PR fix the problem by storing the class _name_, ensuring we can load the class dynamically when needed, and fixing the root problem. It _does_ still store the class pointer and tries using it as before (as that's likely more performant when loading saves on the same level).  

Possible related issues:
https://github.com/PipeRift/SaveExtension/issues/87
> It looks like the problem is when switching levels and game modes. In the editor, when switching different levels and game modes, the display name/ file path is all 0 and equal.

https://github.com/PipeRift/SaveExtension/issues/79
> using 4.26 and in the editor the plug-in work fine I packed the game and the save system started to not work there

https://github.com/PipeRift/SaveExtension/issues/73
> The current market place object for this does not support 4.26